### PR TITLE
Pin numpy<2 in pyproject.toml to fix build failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy<2"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ external = Extension(
 
 setup(
     name="utils2p",
-    version="1.0.1",
+    version="1.0.2",
     packages=["utils2p", "utils2p.external", "utils2p.external.tifffile"],
     author="Florian Aymanns",
     author_email="florian.aymanns@epfl.ch",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ setup(
     long_description=long_description,
     long_description_content_type="text/x-rst",
     url="https://github.com/NeLy-EPFL/utils2p",
-    setup_requires=["numpy"],
     install_requires=["numpy",
                       "pytest",
                       "scipy",

--- a/utils2p/__init__.py
+++ b/utils2p/__init__.py
@@ -2,4 +2,4 @@ from .main import *
 
 __author__ = "Florian Aymanns"
 __email__ = "florian.aymanns@epfl.ch"
-__version__ = "1.0.0"
+__version__ = "1.0.2"


### PR DESCRIPTION
This PR pins `numpy<2` in `pyproject.toml` to resolve build issues with NumPy 2. Removed `setup_requires=["numpy"]` from `setup.py`, as build dependencies are now managed in `pyproject.toml`. The change should be backwards compatible with Python versions down to 3.6.